### PR TITLE
fix: Add go.mod for Init Example

### DIFF
--- a/example16-init-func/go.mod
+++ b/example16-init-func/go.mod
@@ -1,0 +1,3 @@
+module github.com/go-training/training/example16-init-func
+
+go 1.15


### PR DESCRIPTION
In order to build the **example-16** you need to have valid go.mod because it must resolves its dependencies that are defined in `main.go`